### PR TITLE
Default PR comment body to empty string

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,9 +14,9 @@ async function run() {
     }
 
     const body =
-        context.eventName === "issue_comment"
+        (context.eventName === "issue_comment"
             ? context.payload.comment.body
-            : context.payload.pull_request.body;
+            : context.payload.pull_request.body) || '';
     core.setOutput('comment_body', body);
 
     if (


### PR DESCRIPTION
`body` can be `undefined` on empty Pull Requests, this is causing this action to fail.